### PR TITLE
Add {type: 'module'} as a second argument to the Worker constructor

### DIFF
--- a/src/sessionController.ts
+++ b/src/sessionController.ts
@@ -12,7 +12,7 @@ export const createSession = async (
   proxy: boolean,
 ): Promise<Session | Comlink.Remote<Session>> => {
   if (proxy && typeof document !== "undefined") {
-    const worker = new Worker(new URL("./session.js", import.meta.url));
+    const worker = new Worker(new URL("./session.js", import.meta.url), { type: "module" });
     const Channel = wrap<typeof Session>(worker);
     const session: Remote<Session> = await new Channel(cache_size_mb);
     await session.init(modelPath);


### PR DESCRIPTION
Some module bundlers throw the following error without this argument: 
`ERROR: Web workers cannot have imports or exports without the `type: "module"` option.`