### PR TITLE
Create a tensor when token_type_ids is expected

### DIFF
--- a/src/text/encoder.ts
+++ b/src/text/encoder.ts
@@ -21,6 +21,16 @@ export class Encoder implements Model {
       input_ids: input,
       attention_mask: attentionTensor,
     };
+    if (this.session.ortSession) {
+      const inputNames = await this.session.inputNames();
+      if (inputNames.includes("token_type_ids")) {
+        const typeIdsTensor = new ort.Tensor("int64", new BigInt64Array(input.data.length).fill(0n), [
+          1,
+          input.data.length,
+        ]);
+        encoderFeeds["token_type_ids"] = typeIdsTensor;
+      }
+    }
     const output = await this.session.run(encoderFeeds);
     const result = output[this.outputName];
     return result;


### PR DESCRIPTION
This fixes https://github.com/visheratin/web-ai/issues/12, creating a tensor filled with zeros as the token_type_ids input when the model expects it.